### PR TITLE
[feature] image upload with filepath or raw image data

### DIFF
--- a/hangups/client.py
+++ b/hangups/client.py
@@ -202,6 +202,8 @@ class Client(object):
         data_dict = {}
         for data in CHAT_INIT_REGEX.findall(res.body.decode()):
             try:
+                logger.debug("Attempting to load javascript: {}..."
+                             .format(repr(data[:100])))
                 data = javascript.loads(data)
                 # pylint: disable=invalid-sequence-index
                 data_dict[data['key']] = data['data']

--- a/hangups/client.py
+++ b/hangups/client.py
@@ -11,6 +11,7 @@ import re
 import time
 import datetime
 import os
+
 from hangups import (javascript, parsers, exceptions, http_utils, channel,
                      event, schemas)
 

--- a/hangups/client.py
+++ b/hangups/client.py
@@ -709,7 +709,7 @@ class Client(object):
 
 
     @asyncio.coroutine
-    def createconversation(self, chat_id_list):
+    def createconversation(self, chat_id_list, force_group = False):
         """Create new conversation.
 
         conversation_id must be a valid conversation ID.
@@ -723,7 +723,7 @@ class Client(object):
         client_generated_id = random.randint(0, 2**32)
         body = [
             self._get_request_header(),
-            1 if len(chat_id_list) == 1 else 2,
+            1 if len(chat_id_list) == 1 and not force_group else 2,
             client_generated_id,
             None,
             [[str(chat_id), None, None, "unknown", None, []]

--- a/hangups/client.py
+++ b/hangups/client.py
@@ -712,8 +712,8 @@ class Client(object):
         """Create new conversation.
 
         conversation_id must be a valid conversation ID.
-        chat_id_list is list of users which should be invited to conversation.
-        First chat_id in chat_id_list must be UserList._self_user.id_
+        chat_id_list is list of users which should be invited to conversation
+        (except from yourself).
 
         New conversation ID is returned as res['conversation']['id']['id']
 
@@ -722,7 +722,7 @@ class Client(object):
         client_generated_id = random.randint(0, 2**32)
         body = [
             self._get_request_header(),
-            2,
+            1 if len(chat_id_list) == 1 else 2,
             client_generated_id,
             None,
             [[str(chat_id), None, None, "unknown", None, []]
@@ -756,7 +756,7 @@ class Client(object):
              for chat_id in chat_id_list],
             None,
             [
-                [conversation_id], client_generated_id, 2
+                [conversation_id], client_generated_id, 2, None, 4
             ]
         ]
 


### PR DESCRIPTION
e2e88e1 adds the ability to send raw image data instead of a filename (along with optional extension hint, default: "jpg") for image uploads - the original upload with plain filepath still works as well. also resolves a minor security risk as the original filename included the entire filepath as the file title (you can see this in the gallery view)

the other commits are maintenance merges for work from j16sdiz, xmikos, tdryer on `createconversation()` which are presently on tdryer's hangups master
